### PR TITLE
fix: review screen elements not clickable

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1438,6 +1438,7 @@ a.badge-notification {
 .container,
 .search-container,
 .list-controls,
-.d-header .panel {
+.d-header .panel,
+.reviewable-container {
   pointer-events: all;
 }


### PR DESCRIPTION
## Done
fix: review screen elements not clickable
- add pointer-events:all to .reviewable-container