### PR TITLE
fix: pointer-events workaround does not seem to be needed anymore

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1432,9 +1432,6 @@ a.badge-notification {
   as it's obscured by the discourse wrapper
 */
 #main-outlet-wrapper,
-.d-header {
-  pointer-events: none;
-}
 .container,
 .search-container,
 .list-controls,


### PR DESCRIPTION
tested disabling pointer events:none prop manually and navigating around discourse posts and admin. Did not break anything so far.