### PR TITLE
fix: transparent background on sticky header

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1223,7 +1223,6 @@ Discourse overrides
 
 // **** For main nav ******************
 .d-header {
-  background-color: transparent;
   box-shadow: none;
   height: 56px !important;
   position: absolute !important;


### PR DESCRIPTION
When the page is scrolled down the header becomes sticky and cannot be read with a transparent background as the article shines through.

Removing the transparency and replacing it with the themes background color fixes this.

QA:

- go to e.g. https://discourse.maas.io/t/the-eight-minute-read/11900
- scroll down until header becomes sticky
- inspect the header or find the `.d-header` style in elements Style
- untick the `background-color: rgba(0,0,0,0);` declaration
- scroll up down and check if nothing else breaks
  - navigate around in other areas such as user preferences, admin etc.